### PR TITLE
fix: normalize null transaction fields to undefined

### DIFF
--- a/server/integrations/enablebanking/transactions.ts
+++ b/server/integrations/enablebanking/transactions.ts
@@ -31,9 +31,9 @@ function convertTransaction(
   if (transaction.credit_debit_indicator === 'DBIT') amount *= -1;
 
   const payee =
-    transaction.credit_debit_indicator === 'DBIT'
+    (transaction.credit_debit_indicator === 'DBIT'
       ? transaction.creditor?.name
-      : transaction.debtor?.name;
+      : transaction.debtor?.name) ?? undefined;
 
   const notes =
     [transaction.remittance_information, transaction.note]
@@ -42,7 +42,7 @@ function convertTransaction(
       .join(' | ') || undefined;
 
   const result: Partial<output<typeof Transaction>> = {
-    id: transaction.entry_reference,
+    id: transaction.entry_reference ?? undefined,
     date: rawDate ? new Date(rawDate) : undefined,
     amount,
     currency: transaction.transaction_amount.currency,


### PR DESCRIPTION
## Problem

The Enable Banking API can return `null` for `entry_reference` (mapped to `id`) and `creditor?.name` / `debtor?.name` (mapped to `payee`). The `Transaction` schema uses `.optional()` which accepts `undefined` but **not** `null`, so Zod throws a validation error when these fields are written to history.

Because `loadHistory()` validates the entire history file on every startup, a single `null` value in a persisted transaction permanently crashes the server until the history file is manually repaired.

Fixes #13.

## Root cause

Optional chaining (`?.`) returns `undefined` when the object is nullish, but if the upstream API explicitly sets the property to `null`, optional chaining returns `null` — not `undefined`. The final cast to `output<typeof Transaction>` then bypasses schema validation before the object is written to history.

## Fix

Normalize `null` → `undefined` with `?? undefined` for both `id` and `payee` before building the result object:

```ts
// Before
id: transaction.entry_reference,
const payee =
  transaction.credit_debit_indicator === 'DBIT'
    ? transaction.creditor?.name
    : transaction.debtor?.name;

// After
id: transaction.entry_reference ?? undefined,
const payee =
  (transaction.credit_debit_indicator === 'DBIT'
    ? transaction.creditor?.name
    : transaction.debtor?.name) ?? undefined;
```

This ensures values that are explicitly `null` in the API response are stored as absent fields, which is consistent with the `.optional()` schema definition.