### PR TITLE
Add per-mapping transaction notes prefix/suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Then open https://YOUR-HOSTNAME:3000 in your browser and complete the setup.
 | `HISTORY_LENGTH`       | Number of stored history entries                                                | `10`                            |
 | `ENABLEBANKING_API`    | Enable Banking API                                                              | `https://api.enablebanking.com` |
 | `LOG_LEVEL`            | Log level (`none`, `info`, `debug`)                                             | `info`                          |
-
+| `TRANSACTION_NOTES_PREFIX` | Text prepended to each imported transaction's notes                        | —                               |
+| `TRANSACTION_NOTES_SUFFIX` | Text appended to each imported transaction's notes                         | —                               |
+ 
 ---
 
 ## Recommended Data Directory Permissions

--- a/client/src/Configuration/Schedules/ScheduleAccountMapping/index.tsx
+++ b/client/src/Configuration/Schedules/ScheduleAccountMapping/index.tsx
@@ -19,6 +19,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { remove, setIn } from 'immutable';
 import type { input, output } from 'zod';
@@ -91,7 +92,7 @@ function Item({
       }
     >
       <ListItemText>
-        <Stack spacing={2} sx={{ marginRight: 2 }}>
+          <Stack spacing={2} sx={{ marginRight: 2 }}>
           <FormControl fullWidth>
             <InputLabel id="source-label">Source</InputLabel>
 
@@ -261,6 +262,26 @@ function Item({
               </FormControl>
             </>
           )}
+
+          <TextField
+            label="Notes Prefix"
+            helperText="Text added before each imported transaction's notes. Useful for adding tags like #auto-imported."
+            placeholder={window.enableActual.notesPrefix ?? ''}
+            value={data.notesPrefix ?? ''}
+            onChange={(event) => {
+              handleChange('notesPrefix', event.target.value || undefined);
+            }}
+          />
+
+          <TextField
+            label="Notes Suffix"
+            helperText="Text added after each imported transaction's notes. Useful for adding tags like #auto-imported."
+            placeholder={window.enableActual.notesSuffix ?? ''}
+            value={data.notesSuffix ?? ''}
+            onChange={(event) => {
+              handleChange('notesSuffix', event.target.value || undefined);
+            }}
+          />
         </Stack>
       </ListItemText>
     </ListItem>
@@ -371,7 +392,13 @@ export default function ScheduleAccountMapping({
       <CardActions>
         <Button
           onClick={() => {
-            onChange([...data, {}]);
+            onChange([
+              ...data,
+              {
+                notesPrefix: window.enableActual.notesPrefix || undefined,
+                notesSuffix: window.enableActual.notesSuffix || undefined,
+              },
+            ]);
           }}
           startIcon={<AddIcon />}
         >

--- a/client/src/global.ts
+++ b/client/src/global.ts
@@ -3,6 +3,8 @@ declare global {
     enableActual: {
       appName: string;
       publicURL: string;
+      notesPrefix?: string;
+      notesSuffix?: string;
     };
   }
 }

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
       window.enableActual = {
         appName: '%ENABLEACTUAL_CONFIG_APP_NAME%',
         publicURL: '%ENABLEACTUAL_CONFIG_PUBLIC_URL%',
+        notesPrefix: '%ENABLEACTUAL_CONFIG_NOTES_PREFIX%' || undefined,
+        notesSuffix: '%ENABLEACTUAL_CONFIG_NOTES_SUFFIX%' || undefined,
       };
     </script>
   </head>

--- a/server/config.ts
+++ b/server/config.ts
@@ -32,4 +32,10 @@ export const ENABLEBANKING_API =
 
 export const ACTUAL_DATA_DIR = path.join(DATA_DIR, 'actual');
 
+export const TRANSACTION_NOTES_PREFIX =
+  process.env.TRANSACTION_NOTES_PREFIX ?? '';
+
+export const TRANSACTION_NOTES_SUFFIX =
+  process.env.TRANSACTION_NOTES_SUFFIX ?? '';
+
 export const LOG_LEVEL = process.env.LOG_LEVEL ?? 'info';

--- a/server/integrations/actualbudget/transactions.ts
+++ b/server/integrations/actualbudget/transactions.ts
@@ -5,6 +5,10 @@ import type ResolvedTransaction from '../../../shared/schema/ResolvedTransaction
 import type ScheduleState from '../../../shared/schema/ScheduleState';
 import type TransactionImportBundle from '../../../shared/schema/TransactionImportBundle';
 import { stringifyError, toDateString } from '../../../shared/utils.ts';
+import {
+  TRANSACTION_NOTES_PREFIX,
+  TRANSACTION_NOTES_SUFFIX,
+} from '../../config.ts';
 import ABClient from './ABClient.ts';
 import type { ABTransaction } from './ABClient.types';
 
@@ -17,7 +21,10 @@ function convertResolvedTransaction(
     amount: transaction.details.amount,
     payeeName: transaction.details.payee,
     importedPayee: transaction.details.payee,
-    notes: transaction.details.notes,
+    notes:
+      [TRANSACTION_NOTES_PREFIX, transaction.details.notes, TRANSACTION_NOTES_SUFFIX]
+        .filter(Boolean)
+        .join(' ') || undefined,
     importedID: transaction.details.id,
   };
 }

--- a/server/integrations/actualbudget/transactions.ts
+++ b/server/integrations/actualbudget/transactions.ts
@@ -15,6 +15,9 @@ import type { ABTransaction } from './ABClient.types';
 function convertResolvedTransaction(
   transaction: output<typeof ResolvedTransaction>,
 ): ABTransaction {
+  const prefix = transaction.notesPrefix ?? TRANSACTION_NOTES_PREFIX;
+  const suffix = transaction.notesSuffix ?? TRANSACTION_NOTES_SUFFIX;
+
   return {
     account: transaction.targetAccountID,
     date: toDateString(transaction.details.date),
@@ -22,7 +25,7 @@ function convertResolvedTransaction(
     payeeName: transaction.details.payee,
     importedPayee: transaction.details.payee,
     notes:
-      [TRANSACTION_NOTES_PREFIX, transaction.details.notes, TRANSACTION_NOTES_SUFFIX]
+      [prefix, transaction.details.notes, suffix]
         .filter(Boolean)
         .join(' ') || undefined,
     importedID: transaction.details.id,

--- a/server/resolveClientTemplate.ts
+++ b/server/resolveClientTemplate.ts
@@ -1,11 +1,18 @@
 import fs from 'fs';
 import path from 'path';
-import { APP_NAME, PUBLIC_URL } from './config.ts';
+import {
+  APP_NAME,
+  PUBLIC_URL,
+  TRANSACTION_NOTES_PREFIX,
+  TRANSACTION_NOTES_SUFFIX,
+} from './config.ts';
 
 const templates: { [path: string]: string | undefined } = {};
 const templateParams = {
   ENABLEACTUAL_CONFIG_APP_NAME: APP_NAME,
   ENABLEACTUAL_CONFIG_PUBLIC_URL: PUBLIC_URL,
+  ENABLEACTUAL_CONFIG_NOTES_PREFIX: TRANSACTION_NOTES_PREFIX,
+  ENABLEACTUAL_CONFIG_NOTES_SUFFIX: TRANSACTION_NOTES_SUFFIX,
 };
 
 export default function resolveClientTemplate(

--- a/server/scheduler/createImportJob.ts
+++ b/server/scheduler/createImportJob.ts
@@ -216,11 +216,13 @@ export default function createImportJob(
           .map(([targetAccountID, accounts]) => ({
             targetAccountID,
             transactions: accounts!.flatMap(
-              ({ sourceID, sourceAccountID }) =>
+              ({ sourceID, sourceAccountID, notesPrefix, notesSuffix }) =>
                 bundles[sourceID]?.[sourceAccountID]?.map(
                   (transaction): output<typeof ResolvedTransaction> => ({
                     sourceID,
                     sourceAccountID,
+                    notesPrefix,
+                    notesSuffix,
                     targetID,
                     targetAccountID,
                     details: transaction,

--- a/shared/schema/ResolvedTransaction.ts
+++ b/shared/schema/ResolvedTransaction.ts
@@ -6,5 +6,7 @@ export default strictObject({
   sourceAccountID: string(),
   targetID: string(),
   targetAccountID: string(),
+  notesPrefix: string().optional(),
+  notesSuffix: string().optional(),
   details: Transaction,
 });

--- a/shared/schema/ScheduleAccountMapping.ts
+++ b/shared/schema/ScheduleAccountMapping.ts
@@ -5,4 +5,6 @@ export default strictObject({
   sourceAccountID: string(),
   targetID: string(),
   targetAccountID: string(),
+  notesPrefix: string().optional(),
+  notesSuffix: string().optional(),
 });


### PR DESCRIPTION
Hi, I'd like to contribute a new feature that I've built because I was missing it for my use case.

## Summary:
Add optional prefix/suffix text to imported transaction notes. Values can be set per account mapping in the schedule UI and fall back to `TRANSACTION_NOTES_PREFIX` / `TRANSACTION_NOTES_SUFFIX` env vars when empty.
This is especially useful for [tagging transactions in Actual Budget](https://actualbudget.org/docs/transactions/tags) — e.g. setting the suffix to `#auto-imported` marks every imported transaction with that tag automatically.
## Changes:
- **`shared/schema/ScheduleAccountMapping.ts`** — added optional `notesPrefix`, `notesSuffix` fields
- **`shared/schema/ResolvedTransaction.ts`** — added `notesPrefix`, `notesSuffix` to carry values through the import pipeline
- **`server/config.ts`** — `TRANSACTION_NOTES_PREFIX` and `TRANSACTION_NOTES_SUFFIX` env vars (default: empty)
- **`server/resolveClientTemplate.ts`** — exposes env var values to the client via `window.enableActual`
- **`server/scheduler/createImportJob.ts`** — passes prefix/suffix from account mapping into `ResolvedTransaction`
- **`server/integrations/actualbudget/transactions.ts`** — `convertResolvedTransaction` uses per-mapping prefix/suffix, falling back to env vars
- **`index.html`** — template exposes prefix/suffix to client
- **`client/src/global.ts`** — type definitions for `window.enableActual.notesPrefix/suffix`
- **`client/src/Configuration/Schedules/ScheduleAccountMapping/index.tsx`** — two text fields per mapping (Prefix/Suffix) with helper text; new mappings pre-filled from env vars
- **`README.md`** — documented `TRANSACTION_NOTES_PREFIX` and `TRANSACTION_NOTES_SUFFIX`