### PR TITLE
fix: pass original query params when following continuationKey pagination

### DIFF
--- a/server/integrations/enablebanking/EBClient.ts
+++ b/server/integrations/enablebanking/EBClient.ts
@@ -328,6 +328,9 @@ export default class EBClient {
         ? async () =>
             this.getTransactions({
               accountUID,
+              dateFrom,
+              dateTo,
+              transactionStatus,
               continuationKey: nextContinuationKey,
             })
         : undefined,


### PR DESCRIPTION
First of all — thank you so much for building enable-actual. It's exactly the tool I was looking for to bridge Enable Banking with Actual Budget, and the setup experience is really well done.

## What this fixes

This PR fixes #27 (and the same root cause as #18): when fetching paginated transactions using a `continuationKey`, the `next()` call in `EBClient.getTransactions` was only passing `accountUID` and `continuationKey` — omitting `dateFrom`, `dateTo`, and `transactionStatus`.

Enable Banking's API requires that all original request parameters are repeated on follow-up paginated requests. Banks like Djurslands Bank (DK) validate this strictly and reject the request with a `422 WRONG_REQUEST_PARAMETERS` / `ParameterValidationException`, while other banks apparently tolerate the mismatch silently.

## The fix

```typescript
// Before
next: nextContinuationKey
  ? async () => this.getTransactions({ accountUID, continuationKey: nextContinuationKey })
  : undefined,

// After
next: nextContinuationKey
  ? async () => this.getTransactions({ accountUID, dateFrom, dateTo, transactionStatus, continuationKey: nextContinuationKey })
  : undefined,
```

Three lines added. Tested and confirmed working on Djurslands Bank with 11 accounts — all previously failing with the 422 error, now importing successfully.

This fix was developed with the help of [Claude Code](https://claude.ai/code) (Anthropic's AI coding assistant), which helped trace the pagination logic and identify the missing parameters.

Thanks again for the project — it's genuinely useful! 🙏